### PR TITLE
Fix build warnings from Babel

### DIFF
--- a/babel.config.json
+++ b/babel.config.json
@@ -1,0 +1,3 @@
+{
+  "compact": true
+}


### PR DESCRIPTION
## Summary
- configure Babel to compact large files so build output doesn't warn about `deoptimised` styling

## Testing
- `yarn build >/tmp/build.log && grep -i deoptimised /tmp/build.log`

------
https://chatgpt.com/codex/tasks/task_e_68541a1c1a0c832cb4f029ca9fc98555